### PR TITLE
add deployer account

### DIFF
--- a/scripts/deploy_multicall.js
+++ b/scripts/deploy_multicall.js
@@ -13,7 +13,9 @@ async function main() {
   // manually to make sure everything is compiled
   await hre.run('compile');
 
-  const MulticallFactory = await ethers.getContractFactory("Multicall");
+  [deployer] = await ethers.getSigners();
+
+  const MulticallFactory = await ethers.getContractFactory("Multicall", deployer);
   Multicall = await MulticallFactory.deploy();
   await Multicall.deployed();
   console.log("Multicall deployed to:", Multicall.address);


### PR DESCRIPTION
I often get `transaction underpriced`, but only when deploying `multicall`, and this is the only difference I could spot.